### PR TITLE
Triples on About Page now scale appropriately.

### DIFF
--- a/lib/aboutus.dart
+++ b/lib/aboutus.dart
@@ -34,7 +34,7 @@ class _AboutUsPageState extends State<AboutUsPage> {
                     MediaQuery.of(context).size.width / 30.0,
                   ),
                   child: Container(
-                      height: MediaQuery.of(context).size.height * 1.5,
+                      height: MediaQuery.of(context).size.height * 1.75,
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(15),
                         color: Colors.white,
@@ -154,6 +154,7 @@ class _AboutUsPageState extends State<AboutUsPage> {
   createTriple(pathOne, pathTwo, pathThree, functionOne, functionTwo,
       functionThree, padding) {
     return Container(
+        height: 125,
         padding: padding,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,


### PR DESCRIPTION
### What Changed
When accessing the "About Us" page on a bigger screen (for example, 8'' Tablet), the Triple Buttons would scale themselves, and would end up becoming too big, pushing other elements off screen.
This PR fixes this issue, and gives all Triple Buttons a height value, so they scale appropriately.

### Please Look At
The small changes made to the white background container height, and the height addition to the Triples.