### PR TITLE
Fullscreen video

### DIFF
--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -131,7 +131,7 @@ class _CollectionPageState extends State<CollectionPage> {
             Padding(
               padding: EdgeInsets.all(SizeConfig.edgeINSETS),
               child: Text(
-                "Oral History",
+                "Oral Histories",
                 style: TextStyle(
                     color: Colors.white,
                     fontSize: SizeConfig.fontHEADERSIZE,

--- a/lib/fullscreenVid.dart
+++ b/lib/fullscreenVid.dart
@@ -2,6 +2,32 @@ import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 import 'size_config.dart';
 
+class FullscreenVideo extends StatelessWidget {
+  late final VideoPlayerController controller;
+  FullscreenVideo({Key? key, required this.controller}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        backgroundColor: Colors.black,
+        body: Align(
+            alignment: Alignment.center,
+            child: SizedBox(
+              height: MediaQuery.of(context).orientation == Orientation.portrait
+                  ? MediaQuery.of(context).size.height / 3
+                  : null,
+              child: Stack(
+                alignment: Alignment.bottomCenter,
+                children: <Widget>[
+                  VideoPlayer(controller),
+                  _ControlsOverlay(controller: controller),
+                  VideoProgressIndicator(controller, allowScrubbing: true),
+                ],
+              ),
+            )));
+  }
+}
+
 class _ControlsOverlay extends StatelessWidget {
   const _ControlsOverlay({Key? key, required this.controller})
       : super(key: key);
@@ -19,22 +45,6 @@ class _ControlsOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
-        AnimatedSwitcher(
-          duration: Duration(milliseconds: 50),
-          reverseDuration: Duration(milliseconds: 200),
-          child: controller.value.isPlaying
-              ? SizedBox.shrink()
-              : Container(
-                  color: Colors.black26,
-                  child: Center(
-                    child: Icon(
-                      Icons.play_arrow,
-                      color: Colors.white,
-                      size: 100.0,
-                    ),
-                  ),
-                ),
-        ),
         GestureDetector(
           onTap: () {
             controller.value.isPlaying ? controller.pause() : controller.play();
@@ -79,31 +89,5 @@ class _ControlsOverlay extends StatelessWidget {
         ),
       ],
     );
-  }
-}
-
-class FullscreenVideo extends StatelessWidget {
-  late final VideoPlayerController controller;
-  FullscreenVideo({Key? key, required this.controller}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-        backgroundColor: Colors.black,
-        body: Align(
-            alignment: Alignment.center,
-            child: SizedBox(
-              height: MediaQuery.of(context).orientation == Orientation.portrait
-                  ? MediaQuery.of(context).size.height / 3
-                  : null,
-              child: Stack(
-                alignment: Alignment.bottomCenter,
-                children: <Widget>[
-                  VideoPlayer(controller),
-                  _ControlsOverlay(controller: controller),
-                  VideoProgressIndicator(controller, allowScrubbing: true),
-                ],
-              ),
-            )));
   }
 }

--- a/lib/fullscreenVid.dart
+++ b/lib/fullscreenVid.dart
@@ -90,15 +90,19 @@ class FullscreenVideo extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
         body: Align(
-      alignment: Alignment.center,
-      child: Stack(
-        alignment: Alignment.bottomCenter,
-        children: <Widget>[
-          VideoPlayer(controller),
-          _ControlsOverlay(controller: controller),
-          VideoProgressIndicator(controller, allowScrubbing: true),
-        ],
-      ),
-    ));
+            alignment: Alignment.center,
+            child: SizedBox(
+              height: MediaQuery.of(context).orientation == Orientation.portrait
+                  ? SizeConfig.screenHeight / 2.5
+                  : null,
+              child: Stack(
+                alignment: Alignment.bottomCenter,
+                children: <Widget>[
+                  VideoPlayer(controller),
+                  _ControlsOverlay(controller: controller),
+                  VideoProgressIndicator(controller, allowScrubbing: true),
+                ],
+              ),
+            )));
   }
 }

--- a/lib/fullscreenVid.dart
+++ b/lib/fullscreenVid.dart
@@ -89,11 +89,12 @@ class FullscreenVideo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+        backgroundColor: Colors.black,
         body: Align(
             alignment: Alignment.center,
             child: SizedBox(
               height: MediaQuery.of(context).orientation == Orientation.portrait
-                  ? SizeConfig.screenHeight / 2.5
+                  ? MediaQuery.of(context).size.height / 3
                   : null,
               child: Stack(
                 alignment: Alignment.bottomCenter,

--- a/lib/fullscreenVid.dart
+++ b/lib/fullscreenVid.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+import 'size_config.dart';
+
+class _ControlsOverlay extends StatelessWidget {
+  const _ControlsOverlay({Key? key, required this.controller})
+      : super(key: key);
+
+  static const _examplePlaybackRates = [
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+  ];
+
+  final VideoPlayerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        AnimatedSwitcher(
+          duration: Duration(milliseconds: 50),
+          reverseDuration: Duration(milliseconds: 200),
+          child: controller.value.isPlaying
+              ? SizedBox.shrink()
+              : Container(
+                  color: Colors.black26,
+                  child: Center(
+                    child: Icon(
+                      Icons.play_arrow,
+                      color: Colors.white,
+                      size: 100.0,
+                    ),
+                  ),
+                ),
+        ),
+        GestureDetector(
+          onTap: () {
+            controller.value.isPlaying ? controller.pause() : controller.play();
+          },
+        ),
+        Align(
+          alignment: Alignment.topRight,
+          child: PopupMenuButton<double>(
+            initialValue: controller.value.playbackSpeed,
+            tooltip: 'Playback speed',
+            onSelected: (speed) {
+              controller.setPlaybackSpeed(speed);
+            },
+            itemBuilder: (context) {
+              return [
+                for (final speed in _examplePlaybackRates)
+                  PopupMenuItem(
+                    value: speed,
+                    child: Text('${speed}x',
+                        style: TextStyle(
+                            fontSize: SizeConfig.fontDISCRIPTIONSIZE,
+                            color: Colors.black,
+                            fontWeight: FontWeight.bold)),
+                  )
+              ];
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                // Using less vertical padding as the text is also longer
+                // horizontally, so it feels like it would need more spacing
+                // horizontally (matching the aspect ratio of the video).
+                vertical: 12,
+                horizontal: 16,
+              ),
+              child: Text('${controller.value.playbackSpeed}x',
+                  style: TextStyle(
+                      fontSize: SizeConfig.fontDISCRIPTIONSIZE,
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold)),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class FullscreenVideo extends StatelessWidget {
+  late final VideoPlayerController controller;
+  FullscreenVideo({Key? key, required this.controller}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: Align(
+      alignment: Alignment.center,
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: <Widget>[
+          VideoPlayer(controller),
+          _ControlsOverlay(controller: controller),
+          VideoProgressIndicator(controller, allowScrubbing: true),
+        ],
+      ),
+    ));
+  }
+}

--- a/lib/fullscreenVid.dart
+++ b/lib/fullscreenVid.dart
@@ -21,6 +21,8 @@ class _ControllerVideo extends StatefulWidget {
 }
 
 class _ControllerVideoState extends State<_ControllerVideo> {
+  late VideoPlayerController _controller;
+
   @override
   void initState() {
     super.initState();
@@ -28,6 +30,7 @@ class _ControllerVideoState extends State<_ControllerVideo> {
       DeviceOrientation.landscapeRight,
       DeviceOrientation.landscapeLeft,
     ]);
+    _controller = widget.controller;
   }
 
   @override
@@ -54,23 +57,12 @@ class _ControllerVideoState extends State<_ControllerVideo> {
               child: Stack(
                 alignment: Alignment.bottomCenter,
                 children: <Widget>[
-                  VideoPlayer(widget.controller),
-                  _ControlsOverlay(controller: widget.controller),
-                  VideoProgressIndicator(widget.controller,
-                      allowScrubbing: true),
+                  VideoPlayer(_controller),
+                  _ControlsOverlay(controller: _controller),
+                  VideoProgressIndicator(_controller, allowScrubbing: true),
                 ],
               ),
             )));
-  }
-}
-
-class _FullScreenState extends State<FullscreenVideo> {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: SizeConfig.backroundCOLOR,
-      body: _ControllerVideo(widget.key, widget.controller),
-    );
   }
 }
 
@@ -91,22 +83,6 @@ class _ControlsOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
-        AnimatedSwitcher(
-          duration: Duration(milliseconds: 50),
-          reverseDuration: Duration(milliseconds: 200),
-          child: controller.value.isPlaying
-              ? SizedBox.shrink()
-              : Container(
-                  color: Colors.black26,
-                  child: Center(
-                    child: Icon(
-                      Icons.play_arrow,
-                      color: Colors.white,
-                      size: 100.0,
-                    ),
-                  ),
-                ),
-        ),
         GestureDetector(
           onTap: () {
             controller.value.isPlaying ? controller.pause() : controller.play();
@@ -150,6 +126,16 @@ class _ControlsOverlay extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+class _FullScreenState extends State<FullscreenVideo> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: SizeConfig.backroundCOLOR,
+      body: _ControllerVideo(widget.key, widget.controller),
     );
   }
 }

--- a/lib/fullscreenVid.dart
+++ b/lib/fullscreenVid.dart
@@ -1,10 +1,45 @@
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
+import 'package:flutter/services.dart';
 import 'size_config.dart';
 
-class FullscreenVideo extends StatelessWidget {
+class FullscreenVideo extends StatefulWidget {
   late final VideoPlayerController controller;
   FullscreenVideo({Key? key, required this.controller}) : super(key: key);
+
+  @override
+  _FullScreenState createState() => _FullScreenState();
+}
+
+class _ControllerVideo extends StatefulWidget {
+  late final VideoPlayerController controller;
+
+  _ControllerVideo(Key? key, this.controller) : super(key: key);
+
+  @override
+  _ControllerVideoState createState() => _ControllerVideoState();
+}
+
+class _ControllerVideoState extends State<_ControllerVideo> {
+  @override
+  void initState() {
+    super.initState();
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeRight,
+      DeviceOrientation.landscapeLeft,
+    ]);
+  }
+
+  @override
+  void dispose() {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeRight,
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -19,12 +54,23 @@ class FullscreenVideo extends StatelessWidget {
               child: Stack(
                 alignment: Alignment.bottomCenter,
                 children: <Widget>[
-                  VideoPlayer(controller),
-                  _ControlsOverlay(controller: controller),
-                  VideoProgressIndicator(controller, allowScrubbing: true),
+                  VideoPlayer(widget.controller),
+                  _ControlsOverlay(controller: widget.controller),
+                  VideoProgressIndicator(widget.controller,
+                      allowScrubbing: true),
                 ],
               ),
             )));
+  }
+}
+
+class _FullScreenState extends State<FullscreenVideo> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: SizeConfig.backroundCOLOR,
+      body: _ControllerVideo(widget.key, widget.controller),
+    );
   }
 }
 
@@ -45,6 +91,22 @@ class _ControlsOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
+        AnimatedSwitcher(
+          duration: Duration(milliseconds: 50),
+          reverseDuration: Duration(milliseconds: 200),
+          child: controller.value.isPlaying
+              ? SizedBox.shrink()
+              : Container(
+                  color: Colors.black26,
+                  child: Center(
+                    child: Icon(
+                      Icons.play_arrow,
+                      color: Colors.white,
+                      size: 100.0,
+                    ),
+                  ),
+                ),
+        ),
         GestureDetector(
           onTap: () {
             controller.value.isPlaying ? controller.pause() : controller.play();

--- a/lib/size_config.dart
+++ b/lib/size_config.dart
@@ -31,6 +31,7 @@ class SizeConfig {
       20.0; // if unsure what to use use this as default
 
   static const double jamsLogoSize = 120.0; // Logo size as per home page
+  static const double logoSize = 40.0; // Logo size as per home page
 
   void init(BuildContext context) {
     _mediaQueryData = MediaQuery.of(context); // Gets the size of our screen

--- a/lib/size_config.dart
+++ b/lib/size_config.dart
@@ -31,7 +31,7 @@ class SizeConfig {
       20.0; // if unsure what to use use this as default
 
   static const double jamsLogoSize = 120.0; // Logo size as per home page
-  static const double logoSize = 40.0; // Logo size as per home page
+  static const double logoSize = 40.0; // Logo size for video
 
   void init(BuildContext context) {
     _mediaQueryData = MediaQuery.of(context); // Gets the size of our screen

--- a/lib/videoView.dart
+++ b/lib/videoView.dart
@@ -27,6 +27,70 @@ class _RemoteVideo extends StatefulWidget {
   _RemoteVideoState createState() => _RemoteVideoState();
 }
 
+class _ControlsOverlay extends StatelessWidget {
+  const _ControlsOverlay({Key? key, required this.controller})
+      : super(key: key);
+
+  static const _examplePlaybackRates = [
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+  ];
+
+  final VideoPlayerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        GestureDetector(
+          onTap: () {
+            controller.value.isPlaying ? controller.pause() : controller.play();
+          },
+        ),
+        Align(
+          alignment: Alignment.topRight,
+          child: PopupMenuButton<double>(
+            initialValue: controller.value.playbackSpeed,
+            tooltip: 'Playback speed',
+            onSelected: (speed) {
+              controller.setPlaybackSpeed(speed);
+            },
+            itemBuilder: (context) {
+              return [
+                for (final speed in _examplePlaybackRates)
+                  PopupMenuItem(
+                    value: speed,
+                    child: Text('${speed}x',
+                        style: TextStyle(
+                            fontSize: SizeConfig.fontDISCRIPTIONSIZE,
+                            color: Colors.black,
+                            fontWeight: FontWeight.bold)),
+                  )
+              ];
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                // Using less vertical padding as the text is also longer
+                // horizontally, so it feels like it would need more spacing
+                // horizontally (matching the aspect ratio of the video).
+                vertical: 12,
+                horizontal: 16,
+              ),
+              child: Text('${controller.value.playbackSpeed}x',
+                  style: TextStyle(
+                      fontSize: SizeConfig.fontDISCRIPTIONSIZE,
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold)),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class _RemoteVideoState extends State<_RemoteVideo> {
   late VideoPlayerController _controller;
 
@@ -106,86 +170,6 @@ class _RemoteVideoState extends State<_RemoteVideo> {
               ))
         ],
       ),
-    );
-  }
-}
-
-class _ControlsOverlay extends StatelessWidget {
-  const _ControlsOverlay({Key? key, required this.controller})
-      : super(key: key);
-
-  static const _examplePlaybackRates = [
-    0.5,
-    1.0,
-    1.5,
-    2.0,
-  ];
-
-  final VideoPlayerController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return Stack(
-      children: <Widget>[
-        AnimatedSwitcher(
-          duration: Duration(milliseconds: 50),
-          reverseDuration: Duration(milliseconds: 200),
-          child: controller.value.isPlaying
-              ? SizedBox.shrink()
-              : Container(
-                  color: Colors.black26,
-                  child: Center(
-                    child: Icon(
-                      Icons.play_arrow,
-                      color: Colors.white,
-                      size: 100.0,
-                    ),
-                  ),
-                ),
-        ),
-        GestureDetector(
-          onTap: () {
-            controller.value.isPlaying ? controller.pause() : controller.play();
-          },
-        ),
-        Align(
-          alignment: Alignment.topRight,
-          child: PopupMenuButton<double>(
-            initialValue: controller.value.playbackSpeed,
-            tooltip: 'Playback speed',
-            onSelected: (speed) {
-              controller.setPlaybackSpeed(speed);
-            },
-            itemBuilder: (context) {
-              return [
-                for (final speed in _examplePlaybackRates)
-                  PopupMenuItem(
-                    value: speed,
-                    child: Text('${speed}x',
-                        style: TextStyle(
-                            fontSize: SizeConfig.fontDISCRIPTIONSIZE,
-                            color: Colors.black,
-                            fontWeight: FontWeight.bold)),
-                  )
-              ];
-            },
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                // Using less vertical padding as the text is also longer
-                // horizontally, so it feels like it would need more spacing
-                // horizontally (matching the aspect ratio of the video).
-                vertical: 12,
-                horizontal: 16,
-              ),
-              child: Text('${controller.value.playbackSpeed}x',
-                  style: TextStyle(
-                      fontSize: SizeConfig.fontDISCRIPTIONSIZE,
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold)),
-            ),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/videoView.dart
+++ b/lib/videoView.dart
@@ -79,7 +79,7 @@ class _RemoteVideoState extends State<_RemoteVideo> {
                         alignment: Alignment.bottomRight,
                         child: Icon(
                           Icons.fullscreen,
-                          color: SizeConfig.backroundCOLOR,
+                          color: Colors.white,
                           size: SizeConfig.logoSize,
                         )),
                   )

--- a/lib/videoView.dart
+++ b/lib/videoView.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:jamhs_flutter/fullscreenVid.dart';
 import 'package:video_player/video_player.dart';
 import 'size_config.dart';
 
@@ -66,6 +67,22 @@ class _RemoteVideoState extends State<_RemoteVideo> {
                   VideoPlayer(_controller),
                   _ControlsOverlay(controller: _controller),
                   VideoProgressIndicator(_controller, allowScrubbing: true),
+                  GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) =>
+                                  FullscreenVideo(controller: _controller)));
+                    },
+                    child: Align(
+                        alignment: Alignment.bottomRight,
+                        child: Icon(
+                          Icons.fullscreen,
+                          color: SizeConfig.backroundCOLOR,
+                          size: SizeConfig.logoSize,
+                        )),
+                  )
                 ],
               ),
             ),


### PR DESCRIPTION
### What Changed
A fullscreen icon is now added to the Video Player section.
Pressing it opens up the video in Fullscreen, and the phone is forced to landscape mode, so the video takes up the entire screen.
Video duration, scrubbing and playback rate is carried over through to the Fullscreen video layout.


### Please Look at
fullscreenVid.dart for how it is set up.
Please also pull down this branch and checkout to it, and give it a try on your own device you use for developing.

### NOTES:
As per Oggie's request, the Collections tab for videos is now changed to "Oral Histories" instead of "Oral History".

I had to remove the Play Video button during Fullscreen, as there was a discrepancy between the two screens, which would cause the Play Video button to not disappear when in Fullscreen. I will try to come back to this issue later on.