### PR TITLE
JAMHS Link for About Us

### DIFF
--- a/lib/aboutus.dart
+++ b/lib/aboutus.dart
@@ -51,7 +51,7 @@ class _AboutUsPageState extends State<AboutUsPage> {
               SizeConfig.edgeINSETS,
             ),
             child: Container(
-              height: SizeConfig.safeBlockVertical * 241, // 195 isbottom limit
+              height: SizeConfig.safeBlockVertical * 250, // 195 isbottom limit
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(SizeConfig.borderRADIUS),
                 color: Colors.white,
@@ -125,19 +125,15 @@ class _AboutUsPageState extends State<AboutUsPage> {
                       launchFacebook,
                       launchInsta,
                       launchTwitter,
-                      EdgeInsets.fromLTRB(
-                          SizeConfig.blockSizeHorizontal * 5,
-                          0,
-                          SizeConfig.blockSizeHorizontal * 5,
-                          SizeConfig.blockSizeHorizontal * 3)),
+                      EdgeInsets.fromLTRB(SizeConfig.blockSizeHorizontal * 5, 0,
+                          SizeConfig.blockSizeHorizontal * 5, 0)),
+                  createText("Visit our Website", SizeConfig.edgeINSETS,
+                      SizeConfig.fontHEADERSIZE, FontWeight.bold),
                   createImage(
                       "assets/logo/jamhs.jpg",
                       SizeConfig.edgeINSETS, // border's radius
-                      EdgeInsets.fromLTRB(
-                          SizeConfig.blockSizeHorizontal * 30,
-                          0,
-                          SizeConfig.blockSizeHorizontal * 30,
-                          SizeConfig.blockSizeHorizontal * 2),
+                      EdgeInsets.fromLTRB(SizeConfig.blockSizeHorizontal * 30,
+                          0, SizeConfig.blockSizeHorizontal * 30, 0),
                       launchJAHMS),
                 ],
               ),

--- a/lib/aboutus.dart
+++ b/lib/aboutus.dart
@@ -51,7 +51,7 @@ class _AboutUsPageState extends State<AboutUsPage> {
               SizeConfig.edgeINSETS,
             ),
             child: Container(
-              height: SizeConfig.safeBlockVertical * 250, // 195 isbottom limit
+              height: SizeConfig.safeBlockVertical * 230, // 195 isbottom limit
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(SizeConfig.borderRADIUS),
                 color: Colors.white,
@@ -307,7 +307,7 @@ class _AboutUsPageState extends State<AboutUsPage> {
   createTriple(pathOne, pathTwo, pathThree, functionOne, functionTwo,
       functionThree, padding) {
     return Container(
-        height: SizeConfig.blockSizeVertical * 30,
+        height: SizeConfig.blockSizeVertical * 20,
         padding: padding,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,

--- a/lib/aboutus.dart
+++ b/lib/aboutus.dart
@@ -51,7 +51,7 @@ class _AboutUsPageState extends State<AboutUsPage> {
               SizeConfig.edgeINSETS,
             ),
             child: Container(
-              height: SizeConfig.safeBlockVertical * 230, // 195 isbottom limit
+              height: SizeConfig.safeBlockVertical * 241, // 195 isbottom limit
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(SizeConfig.borderRADIUS),
                 color: Colors.white,
@@ -127,9 +127,18 @@ class _AboutUsPageState extends State<AboutUsPage> {
                       launchTwitter,
                       EdgeInsets.fromLTRB(
                           SizeConfig.blockSizeHorizontal * 5,
-                          SizeConfig.blockSizeHorizontal * 3,
+                          0,
                           SizeConfig.blockSizeHorizontal * 5,
                           SizeConfig.blockSizeHorizontal * 3)),
+                  createImage(
+                      "assets/logo/jamhs.jpg",
+                      SizeConfig.edgeINSETS, // border's radius
+                      EdgeInsets.fromLTRB(
+                          SizeConfig.blockSizeHorizontal * 30,
+                          0,
+                          SizeConfig.blockSizeHorizontal * 30,
+                          SizeConfig.blockSizeHorizontal * 2),
+                      launchJAHMS),
                 ],
               ),
             ),
@@ -377,6 +386,15 @@ class _AboutUsPageState extends State<AboutUsPage> {
 
   void launchTwitter() async {
     const url = 'https://twitter.com/';
+    if (await canLaunch(url)) {
+      await launch(url);
+    } else {
+      throw 'Could not launch $url';
+    }
+  }
+
+  void launchJAHMS() async {
+    const url = 'https://jewishmilitary.com/';
     if (await canLaunch(url)) {
       await launch(url);
     } else {


### PR DESCRIPTION
## What Changed
The JAMHS Logo is now added to the About Us page, and can be tapped to open the [relevant website](https://jewishmilitary.com/).
Added Text to say "Visit Our Website" so it's apparent the image can be clicked, like the other elements.

## Please Look At
aboutus.dart for how the new image was added and set up.

## NOTE:
The Height for the Triples was over-exaggerated, which caused it to take up more space than it needed, so I re-adjusted the size so it takes up less height space.