### PR TITLE
Back Button for Fullscreen Video

### DIFF
--- a/lib/fullscreenVid.dart
+++ b/lib/fullscreenVid.dart
@@ -60,6 +60,9 @@ class _ControllerVideoState extends State<_ControllerVideo> {
                   VideoPlayer(_controller),
                   _ControlsOverlay(controller: _controller),
                   VideoProgressIndicator(_controller, allowScrubbing: true),
+                  Align(
+                      alignment: Alignment.topLeft,
+                      child: BackButton(color: Colors.white)),
                 ],
               ),
             )));

--- a/lib/videoView.dart
+++ b/lib/videoView.dart
@@ -44,6 +44,22 @@ class _ControlsOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
+        AnimatedSwitcher(
+          duration: Duration(milliseconds: 50),
+          reverseDuration: Duration(milliseconds: 200),
+          child: controller.value.isPlaying
+              ? SizedBox.shrink()
+              : Container(
+                  color: Colors.black26,
+                  child: Center(
+                    child: Icon(
+                      Icons.play_arrow,
+                      color: Colors.white,
+                      size: 100.0,
+                    ),
+                  ),
+                ),
+        ),
         GestureDetector(
           onTap: () {
             controller.value.isPlaying ? controller.pause() : controller.play();


### PR DESCRIPTION
## What Changed
Fullscreen Video now has a Back Button on the Top Left, so you can press that instead of pressing the Back Button on your device.
This change was made as a result of iOS devices not having a dedicated Back Button.

## Please Look At
fullscreenVid.dart for the BackButton widget implementation.
Please also run it on your device and confirm that the Back Button works and can be tapped without any issues.

## NOTE:
I also added a missing Play button visual to the main video screen view, as it was removed in a previous Pull Request.